### PR TITLE
Fixing cmake build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(MarchingTetrahedrons)
 
+set(OpenGL_GL_PREFERENCE GLVND)
+
 add_executable(MarchingTetrahedrons
     common.h
     Array3D.h
@@ -19,6 +21,16 @@ add_executable(MarchingTetrahedrons
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)
 
+target_include_directories(MarchingTetrahedrons PRIVATE ${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS})
+
 target_link_libraries(MarchingTetrahedrons PRIVATE
     OpenGL::GL
     GLUT::GLUT)
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(MarchingTetrahedrons PRIVATE GLU)
+endif()
+
+if(WIN32)
+    target_link_libraries(MarchingTetrahedrons PRIVATE glu32)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(MarchingTetrahedrons)
 
-set(OpenGL_GL_PREFERENCE GLVND)
-
 add_executable(MarchingTetrahedrons
     common.h
     Array3D.h
@@ -21,16 +19,8 @@ add_executable(MarchingTetrahedrons
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)
 
-target_include_directories(MarchingTetrahedrons PRIVATE ${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS})
-
 target_link_libraries(MarchingTetrahedrons PRIVATE
     OpenGL::GL
+    OpenGL::GLU
     GLUT::GLUT)
 
-if(UNIX AND NOT APPLE)
-    target_link_libraries(MarchingTetrahedrons PRIVATE GLU)
-endif()
-
-if(WIN32)
-    target_link_libraries(MarchingTetrahedrons PRIVATE glu32)
-endif()


### PR DESCRIPTION
I had errors and warnings about what OpenGL libraries to use and missing references when building the project.

Such as:

```
[build] CMake Warning (dev) at /usr/share/cmake-3.25/Modules/FindOpenGL.cmake:315 (message):
[build]   Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
[build]   available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
[build]   cmake_policy command to set the policy and suppress this warning.
[build] 
[build]   FindOpenGL found both a legacy GL library:
[build] 
[build]     OPENGL_gl_LIBRARY: /usr/lib/x86_64-linux-gnu/libGL.so
[build] 
[build]   and GLVND libraries for OpenGL and GLX:
[build] 
[build]     OPENGL_opengl_LIBRARY: /usr/lib/x86_64-linux-gnu/libOpenGL.so
[build]     OPENGL_glx_LIBRARY: /usr/lib/x86_64-linux-gnu/libGLX.so
[build] 
[build]   OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
[build]   compatibility with CMake 3.10 and below the legacy GL library will be used.
[build] Call Stack (most recent call first):
[build]   CMakeLists.txt:19 (find_package)
[build] This warning is for project developers.  Use -Wno-dev to suppress it.
[build] 
[build] -- Configuring done
[build] -- Generating done
[build] -- Build files have been written to: /projects/MarchingTetrahedrons/build
[build] [ 14%] Linking CXX executable MarchingTetrahedrons
[build] /usr/bin/ld: CMakeFiles/MarchingTetrahedrons.dir/main.cpp.o: in function `changeSize(int, int)':
[build] /projects/MarchingTetrahedrons/main.cpp:81: undefined reference to `gluPerspective'
[build] /usr/bin/ld: /projects/MarchingTetrahedrons/main.cpp:88: undefined reference to `gluLookAt'
[build] clang: error: linker command failed with exit code 1 (use -v to see invocation)
[build] gmake[2]: *** [CMakeFiles/MarchingTetrahedrons.dir/build.make:180: MarchingTetrahedrons] Error 1
[build] gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/MarchingTetrahedrons.dir/all] Error 2
[build] gmake: *** [Makefile:91: all] Error 2
[proc] The command: /usr/bin/cmake --build /projects/MarchingTetrahedrons/build --config Debug --target all -j 10 -- exited with code: 2
[driver] Build completed: 00:00:00.212
[build] Build finished with exit code 2
```